### PR TITLE
Enable syntax highlighting for code blocks in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Click for the [demo](http://oferh.github.io/ng2-completer/)
 ## Usage
 
 `Http` and `forms` should be provided in the app: 
-```
+```ts
 import { bootstrap } from '@angular/platform-browser-dynamic';
 import { disableDeprecatedForms, provideForms } from '@angular/forms';
 
@@ -31,7 +31,7 @@ bootstrap(AppComponent, [
 
 Add ng2-completer to your component and create a data source:
 
-```
+```ts
 import { Component } from '@angular/core';
 import {CompleterCmp, CompleterService, CompleterData, COMPLETER_DATA_PROVIDERS} from 'ng2-completer';
 
@@ -69,19 +69,19 @@ a custome source that generates a stream of items.
 ###System.js configuration
 
 Add the following to `System.js` map configuration:
-```
-   var map = {
-       ...
-       'ng2-completer':              'node_modules/ng2-completer/bundles'
-   }
+```ts
+var map = {
+   ...
+   'ng2-completer':              'node_modules/ng2-completer/bundles'
+}
 ```
 
 Add the following to `System.js` packages configuration:
-```
-   var packages = {
-       ...
-       'ng2-completer':              { main: 'ng2-completer.js', format: 'cjs' }
-   }
+```ts
+var packages = {
+   ...
+   'ng2-completer':              { main: 'ng2-completer.js', format: 'cjs' }
+}
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Click for the [demo](http://oferh.github.io/ng2-completer/)
 
 ## Installation
 
-`npm install ng2-completer --save`
+```sh
+npm install ng2-completer --save
+```
 
 ## Usage
 
@@ -20,7 +22,7 @@ import { bootstrap } from '@angular/platform-browser-dynamic';
 import { disableDeprecatedForms, provideForms } from '@angular/forms';
 
 import { AppComponent, environment } from './app/';
-import {HTTP_PROVIDERS} from '@angular/http';
+import { HTTP_PROVIDERS } from '@angular/http';
 
 bootstrap(AppComponent, [
   HTTP_PROVIDERS,
@@ -33,7 +35,7 @@ Add ng2-completer to your component and create a data source:
 
 ```ts
 import { Component } from '@angular/core';
-import {CompleterCmp, CompleterService, CompleterData, COMPLETER_DATA_PROVIDERS} from 'ng2-completer';
+import { CompleterCmp, CompleterService, CompleterData, COMPLETER_DATA_PROVIDERS } from 'ng2-completer';
 
 @Component({
   selector: 'my-component',


### PR DESCRIPTION
From discussion in #34, I added `ts` language identifier to code blocks, and adjusted some whitespaces for consistency in `README.md` file.