### PR TITLE
Added support in RemoteData for HTTP Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Create remote data provider by calling `CompleterService.remote`.
 |imageField|string|Name of the field to use as image url for the list item.|
 |urlFormater|(term: string) => string|Function that get's the searchterm and returns the search url before each search.|
 |dataField|string|The field in the response that includes the data.|
+|headers|Headers (@angular/http)|HTTP request headers that should be sent with the search request.
 
 ### CSS classes
 

--- a/demo/app-cmp.html
+++ b/demo/app-cmp.html
@@ -93,7 +93,7 @@
         </div>
     </div>
 
-    <h2>Remote data with URL Formater</h2>
+    <h2>Remote data with URL Formater and Headers</h2>
     <div class="row completer-wrapper m-a-1">
         <div class="col-md-offset-1">
             <div class="row">

--- a/demo/app-cmp.html
+++ b/demo/app-cmp.html
@@ -97,7 +97,7 @@
     <div class="row completer-wrapper m-a-1">
         <div class="col-md-offset-1">
             <div class="row">
-                <p>Remote data from <a href="https://developers.google.com/maps/documentation/geocoding/start">Google Maps API</a> - urlFormater and dataField</p>
+                <p>Remote data from <a href="https://developers.google.com/maps/documentation/geocoding/start">Google Maps API</a> - urlFormater, dataField, and headers</p>
             </div>
             <div class="row">
                 <ng2-completer [(ngModel)]="countryName5" [dataService]="dataRemote2" [minSearchLength]="3" [placeholder]="'search country'" [textSearching]="'Please wait...'">

--- a/demo/app-cmp.ts
+++ b/demo/app-cmp.ts
@@ -85,7 +85,7 @@ export class AppComponent {
             return `https://maps.googleapis.com/maps/api/geocode/json?address=${term}`;
         });
         this.dataRemote2.dataField("results");
-        this.dataRemote2.headers(new Headers({"X-User-Token":"Hello World!"}));
+        this.dataRemote2.headers(new Headers({"My-Header":"Hello World!"}));
         this.dataService3 = completerService.local(this.countries, "name", "name");
         this.dataService4 = completerService.local(this.countries, "name", "name");
         this.customData = new CustomData(http);

--- a/demo/app-cmp.ts
+++ b/demo/app-cmp.ts
@@ -85,6 +85,7 @@ export class AppComponent {
             return `https://maps.googleapis.com/maps/api/geocode/json?address=${term}`;
         });
         this.dataRemote2.dataField("results");
+        this.dataRemote2.headers(new Headers({"X-User-Token":"Hello World!"}));
         this.dataService3 = completerService.local(this.countries, "name", "name");
         this.dataService4 = completerService.local(this.countries, "name", "name");
         this.customData = new CustomData(http);

--- a/demo/app-cmp.ts
+++ b/demo/app-cmp.ts
@@ -5,7 +5,7 @@ import "rxjs/Rx";
 
 import { CompleterService, CompleterData, CompleterItem, RemoteData } from "../src/ng2-completer";
 import { CustomData } from "./custom-data";
-import { Http } from "@angular/http";
+import { Http, Headers } from "@angular/http";
 
 let template = require("./app-cmp.html");
 let style = require("./app-cmp.css");

--- a/src/components/ng2-completer/services/remote-data.ts
+++ b/src/components/ng2-completer/services/remote-data.ts
@@ -1,4 +1,4 @@
-import {Http, Response} from "@angular/http";
+import { Http, Response, Headers } from "@angular/http";
 import {Subscription} from "rxjs/Subscription";
 import "rxjs/add/operator/map";
 import "rxjs/add/operator/catch";
@@ -11,6 +11,8 @@ export class RemoteData extends CompleterBaseData {
     private remoteSearch: Subscription;
     private _urlFormater: (term: string) => string = null;
     private _dataField: string = null;
+    private _headers: Headers;
+
 
     constructor(private http: Http) {
         super();
@@ -29,6 +31,10 @@ export class RemoteData extends CompleterBaseData {
         this._dataField = dataField;
     }
 
+    public headers(headers:Headers) {
+        this._headers = headers;
+    }
+
     public search(term: string): void {
         this.cancel();
         // let params = {};
@@ -39,7 +45,7 @@ export class RemoteData extends CompleterBaseData {
             url = this._remoteUrl + encodeURIComponent(term);
         }
 
-        this.remoteSearch = this.http.get(url)
+        this.remoteSearch = this.http.get(url, { headers: this._headers || new Headers()})
             .map((res: Response) => res.json())
             .map((data: any) => {
                 let matchaes = this.extractValue(data, this._dataField);


### PR DESCRIPTION
Added a new method  `headers` in `RemoteData` that accepts a `Headers` object and passes it into the HTTP GET request options.  Related to issue #29 