### PR TITLE
WIP: Fix `keyup` event is not fired on Firefox on Android when word suggestion is on

### DIFF
--- a/src/directives/ctr-input.ts
+++ b/src/directives/ctr-input.ts
@@ -24,29 +24,7 @@ export class CtrInput {
     private _searchStr = "";
     private _displayStr = "";
 
-    constructor( @Host() private completer: CtrCompleter) {
-        this.completer.selected.subscribe((item: CompleterItem) => {
-            if (this.clearSelected) {
-                this.searchStr = "";
-            } else {
-                this.searchStr = item.title;
-            }
-            this.ngModelChange.emit(this.searchStr);
-        });
-        this.completer.highlighted.subscribe((item: CompleterItem) => {
-            this._displayStr = item.title;
-            this.ngModelChange.emit(item.title);
-        });
-    }
-
-    @HostListener("input", ["$event"])
-    public onInputChange(event: any) {
-        this.searchStr = event.target.value;
-    }
-
-    @HostListener("keyup", ["$event"])
-    public keyupHandler(event: any) {
-
+		private _handleInputEvents(event: any) {
         if (event.keyCode === KEY_LF || event.keyCode === KEY_RT || event.keyCode === KEY_TAB) {
             // do nothing
             return;
@@ -72,7 +50,32 @@ export class CtrInput {
 
             this.completer.search(this.searchStr);
         }
+		}
 
+    constructor( @Host() private completer: CtrCompleter) {
+        this.completer.selected.subscribe((item: CompleterItem) => {
+            if (this.clearSelected) {
+                this.searchStr = "";
+            } else {
+                this.searchStr = item.title;
+            }
+            this.ngModelChange.emit(this.searchStr);
+        });
+        this.completer.highlighted.subscribe((item: CompleterItem) => {
+            this._displayStr = item.title;
+            this.ngModelChange.emit(item.title);
+        });
+    }
+
+    @HostListener("input", ["$event"])
+    public onInputChange(event: any) {
+        this.searchStr = event.target.value;
+				this._handleInputEvents(event);
+    }
+
+    @HostListener("keyup", ["$event"])
+    public keyupHandler(event: any) {
+				this._handleInputEvents(event);
     }
 
     @HostListener("keydown", ["$event"])

--- a/src/directives/ctr-input.ts
+++ b/src/directives/ctr-input.ts
@@ -24,7 +24,7 @@ export class CtrInput {
     private _searchStr = "";
     private _displayStr = "";
 
-		private _handleInputEvents(event: any) {
+    private handleInputEvents(event: any) {
         if (event.keyCode === KEY_LF || event.keyCode === KEY_RT || event.keyCode === KEY_TAB) {
             // do nothing
             return;
@@ -70,12 +70,12 @@ export class CtrInput {
     @HostListener("input", ["$event"])
     public onInputChange(event: any) {
         this.searchStr = event.target.value;
-				this._handleInputEvents(event);
+				this.handleInputEvents(event);
     }
 
     @HostListener("keyup", ["$event"])
     public keyupHandler(event: any) {
-				this._handleInputEvents(event);
+				this.handleInputEvents(event);
     }
 
     @HostListener("keydown", ["$event"])

--- a/src/directives/ctr-input.ts
+++ b/src/directives/ctr-input.ts
@@ -24,7 +24,17 @@ export class CtrInput {
     private _searchStr = "";
     private _displayStr = "";
 
+    private _keyupActive: boolean = false;
+
     private handleInputEvents(event: any) {
+
+        // this method is called by both `input` and `keyup` event.
+        // to prevent double-queries, only do the search only once.
+        // `_keyupActive` is set to `true` for `keyup` event and set to `false` for `input` event.
+        if (this._keyupActive) {
+            return;
+        }
+
         if (event.keyCode === KEY_LF || event.keyCode === KEY_RT || event.keyCode === KEY_TAB) {
             // do nothing
             return;
@@ -50,7 +60,7 @@ export class CtrInput {
 
             this.completer.search(this.searchStr);
         }
-		}
+    }
 
     constructor( @Host() private completer: CtrCompleter) {
         this.completer.selected.subscribe((item: CompleterItem) => {
@@ -70,12 +80,14 @@ export class CtrInput {
     @HostListener("input", ["$event"])
     public onInputChange(event: any) {
         this.searchStr = event.target.value;
-				this.handleInputEvents(event);
+        this._keyupActive = false;
+        this.handleInputEvents(event);
     }
 
     @HostListener("keyup", ["$event"])
     public keyupHandler(event: any) {
-				this.handleInputEvents(event);
+        this._keyupActive = true;
+        this.handleInputEvents(event);
     }
 
     @HostListener("keydown", ["$event"])


### PR DESCRIPTION
I tested the demo page on Firefox for Android, the autocomplete doesn't work. I searched a bit more on StackOverflow, and it seems like Firefox for Android has a weird bug that `keyup` event is not fired when word suggestion is on http://stackoverflow.com/q/14194247/2095201. 

Tested Device: **Nexus 5x**
Android Version: **7.0**
Browsers: **Firefox 49, Chrome 53**

When I turn **both** 2 options _Show Suggestions_ and _Auto-correction_ off, the autocomplete works properly.

![screenshot_20161014-123659](https://cloud.githubusercontent.com/assets/911894/19383165/4dff9fde-922d-11e6-99f2-f9d68288313c.png)

This issue doesn't happen on Chrome.

---

Like mentioned in the SO thread's answer, I thought the solution maybe to bind both `input` and `keyup` events to perform the search. Since I'm still pretty new to Angular 2 and don't know the correct way to bind 2 events with the same method in the class, so I moved some code to a shared method so both events can use.

The changes I made can make it works in Firefox for Android. The problem now is that, for other browsers, `_handleInputEvents()` method is called twice per keystroke.

Do you have any suggestions to work this out? It would be nice to see this works also on Firefox for Android. 😃 
