### PR TITLE
add extra nullchecks, before toLocaleLowerCase()

### DIFF
--- a/src/directives/ctr-list.ts
+++ b/src/directives/ctr-list.ts
@@ -54,7 +54,7 @@ export class CtrList implements OnInit, CompleterList {
                     this.ctx.searchInitialized = true;
                     this.ctx.searching = false;
                     this.ctx.results = results;
-                    if (this.ctrListAutoMatch && results.length === 1 &&
+                    if (this.ctrListAutoMatch && results.length === 1 && results[0].title && this.term &&
                         results[0].title.toLocaleLowerCase() === this.term.toLocaleLowerCase()) {
                         // Do automatch
                         this.completer.onSelected(results[0]);


### PR DESCRIPTION
I came across some weird edge-case, where I would hide the ng2-completer component with *ngIf.
I haven't had to the time to dig deeper, if it's deeper problem, but it seems to be resolved by adding to extra checks before calling toLocaleLowerCase().

When I hide it, then show it again, when I type 3 characters it throws: "toLocaleLowerCase() is not a function of null". 

Note: I wasn't able to run ```npm install``` and ```npm start``` or run the tests. No idea why.