### PR TITLE
Bug fix: RemoteData fails to return items when list of objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postbuild:ngc": "cross-env ./node_modules/.bin/ncp .tmp/esm/src dist",
     "copy": "cross-env node copy-dist.js",
     "packagejson": "node ./create-package-json.js",
-    "bundle:umd": "cross-env ./node_modules/.bin/rollup -c rollup.config.js && zopfli dist/ng2-completer.umd.js",
+    "bundle:umd": "cross-env ./node_modules/.bin/rollup -c rollup.config.js",
     "build:demo:dev": "cross-env NG2_COMPLETER_DEMO=y webpack --progress --color",
     "build:demo:prod": "cross-env NG2_COMPLETER_DEMO=y NODE_ENV=production webpack --progress --color",
     "start": "cross-env NG2_COMPLETER_DEMO=y webpack-dev-server --progress",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postbuild:ngc": "cross-env ./node_modules/.bin/ncp .tmp/esm/src dist",
     "copy": "cross-env node copy-dist.js",
     "packagejson": "node ./create-package-json.js",
-    "bundle:umd": "cross-env ./node_modules/.bin/rollup -c rollup.config.js",
+    "bundle:umd": "cross-env ./node_modules/.bin/rollup -c rollup.config.js && zopfli dist/ng2-completer.umd.js",
     "build:demo:dev": "cross-env NG2_COMPLETER_DEMO=y webpack --progress --color",
     "build:demo:prod": "cross-env NG2_COMPLETER_DEMO=y NODE_ENV=production webpack --progress --color",
     "start": "cross-env NG2_COMPLETER_DEMO=y webpack-dev-server --progress",

--- a/src/services/remote-data.ts
+++ b/src/services/remote-data.ts
@@ -49,7 +49,10 @@ export class RemoteData extends CompleterBaseData {
             .map((res: Response) => res.json())
             .map((data: any) => {
                 let matchaes = this.extractValue(data, this._dataField);
-                return this.extractMatches(matchaes, term);
+                // remote data service has already supplied matching items
+                // so there is no need to further "extractMatches," here
+                //return this.extractMatches(matchaes, term);
+                return matchaes;
             })
             .map(
             (matches: any[]) => {


### PR DESCRIPTION
Somewhere between v. 0.2.3 and v. 1.1.0 the extractMatches method in completer-base-data was changed.  This introduced a bug when using RemoteData when the returned data is a list of objects (value.toString() on line 48 of completer-base-data provides "[object Object]", which is not helpful).  Upon investigation, I found that this extractMatches method was being called in the search method of RemoteData, but there doesn't seem to be any need for it: wouldn't your remote data source already only be returning a list of matched items?  So I simply removed the call to extractMatches and my program started working again.