### PR TITLE
Fix production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-completer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ng2 autocomplete/typeahead component",
   "main": "bundles/ng2-completer.js",
   "scripts": {

--- a/src/components/completer-cmp.ts
+++ b/src/components/completer-cmp.ts
@@ -125,6 +125,7 @@ export class CompleterCmp implements OnInit, ControlValueAccessor, AfterViewInit
     @Output() public blur = new EventEmitter<void>();
 
     @ViewChild(CtrCompleter) public completer: CtrCompleter;
+    @ViewChild("ctrInput") public ctrInput: ElementRef;
 
     public searchStr = "";
     public control = new FormControl("");
@@ -132,8 +133,7 @@ export class CompleterCmp implements OnInit, ControlValueAccessor, AfterViewInit
     private displaySearching = true;
     private _onTouchedCallback: () => void = noop;
     private _onChangeCallback: (_: any) => void = noop;
-    @ViewChild("ctrInput") private ctrInput: ElementRef;
-
+    
     constructor(private completerService: CompleterService) { }
 
     get value(): any { return this.searchStr; };


### PR DESCRIPTION
1.2.1 breaks production builds 

<pre>Property 'ctrInput' is private and only accessible within class 'CompleterCmp'</pre>