### PR TITLE
Angular packages are peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "typings": "./bundles/src/index.d.ts",
   "repository": "oferh/ng2-completer",
-  "dependencies": {
+  "peerDependencies": {
     "@angular/common": "^2.1.0",
     "@angular/compiler": "^2.1.0",
     "@angular/core": "^2.1.0",


### PR DESCRIPTION
Make it possible to use it as a dependency under development when we work with an other version of Angular