### PR TITLE
response formatter feature implemented. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Status API Training Shop Blog About Pricing
 
 # Jspm bundle
 src/demo/app-bundle.*
+/nbproject/

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Create remote data provider by calling `CompleterService.remote`.
 |imageField|string|Name of the field to use as image url for the list item.|
 |urlFormater|(term: string) => string|Function that get's the searchterm and returns the search url before each search.|
 |dataField|string|The field in the response that includes the data.|
+|responseFormatter|Function|A function that will modify raw response from remote API before it is rendered in the drop-down. Useful for adding data that may not be available from the API. The specified function must return the object in the format that angucomplete understands.|
 |headers|Headers (@angular/http)|**Deprecated**  use `requestOptions` instead. HTTP request headers that should be sent with the search request.
 |requestOptions|RequestOptions (@angular/http)|HTTP request options that should be sent with the search request.|
 

--- a/demo/native-cmp.html
+++ b/demo/native-cmp.html
@@ -293,4 +293,31 @@
 	</div>
 </div>
 
+<h3>Remote data with response formatter</h3>
+<p>
+    Remote data of countries with 
+    <code>minSearchLength</code>
+    and <code>responseFormatter</code>
+</p>
+
+
+<div class="card">
+	<div class="card-block">
+		<div class="form-group row">
+			<div class="col-5">
+				<ng2-completer 
+                    [dataService]="dataRemoteResponseFormatter" 
+                    [minSearchLength]="1"
+                    [placeholder]="'Search for country'"
+                    (selected)="onCountrySelectedResponseFormatter($event)"
+                    [inputClass]="'form-control'">
+				</ng2-completer>
+            </div>
+			<div class="col-6">
+				<p class="form-control-static"><b> {{countryNameResponseFormatter}}</b></p>
+			</div>
+		</div>
+	</div>
+</div>
+
 <p style="margin-bottom: 10em;"></p>

--- a/demo/native-cmp.ts
+++ b/demo/native-cmp.ts
@@ -68,9 +68,11 @@ export class NativeCmp {
     private dataService: CompleterData;
     private dataService2: CompleterData;
     private countryName2 = "";
+    private countryNameResponseFormatter = "";
     private quote = "";
     private dataRemote: CompleterData;
     private dataRemote2: RemoteData;
+    private dataRemoteResponseFormatter: RemoteData;
     private dataService3: CompleterData;
     private dataService4: CompleterData;
     private customData: CustomData;
@@ -91,12 +93,35 @@ export class NativeCmp {
             return `http://www.omdbapi.com/?s=${term}&type=movie`;
         });
         this.dataRemote2.dataField("Search");
+        this.setDataResponseFormatter(completerService);
         // For async local the source can also be HTTP request
         // let source = http.get("https://raw.githubusercontent.com/oferh/ng2-completer/master/demo/res/data/countries.json?").map((res: any) => res.json());
         let source = Observable.from([this.countries]).delay(3000);
         this.dataService3 = completerService.local(<Observable<any[]>>source, "name", "name");
         this.customData = new CustomData(http);
         this.dataService4 = completerService.local(this.colors, null, null);
+    }
+
+    private setDataResponseFormatter(completerService: CompleterService){
+        this.dataRemoteResponseFormatter = completerService.remote(
+            "https://raw.githubusercontent.com/oferh/ng2-completer/master/demo/res/data/countries.json?",
+            "name",
+            "name");
+        this.dataRemoteResponseFormatter.descriptionField("description");
+        this.dataRemoteResponseFormatter.responseFormatter(function(data:CompleterItem[]):CompleterItem[]{
+            for(let i in data){
+                data[i]['description'] = 'code:' + data[i].originalObject.code;
+            }
+            return data;
+        });
+    }
+    
+    public onCountrySelectedResponseFormatter(selected: CompleterItem) {
+        if (selected) {
+            this.countryNameResponseFormatter = selected.title;
+        } else {
+            this.countryNameResponseFormatter = "";
+        }
     }
 
     public onCountrySelected(selected: CompleterItem) {

--- a/src/services/completer-base-data.ts
+++ b/src/services/completer-base-data.ts
@@ -11,6 +11,7 @@ export abstract class CompleterBaseData extends Subject<CompleterItem[]> impleme
     protected _titleField: string;
     protected _descriptionField: string;
     protected _imageField: string;
+    private formatterFunction:Function;
 
     constructor() {
         super();
@@ -72,6 +73,10 @@ export abstract class CompleterBaseData extends Subject<CompleterItem[]> impleme
 
     }
 
+    public responseFormatter(formatterFunction:Function){
+        this.formatterFunction = formatterFunction;
+    }
+
     protected extractMatches(data: any[], term: string) {
         let matches: any[] = [];
         const searchFields = this._searchFields ? this._searchFields.split(",") : null;
@@ -127,6 +132,17 @@ export abstract class CompleterBaseData extends Subject<CompleterItem[]> impleme
                 }
             }
         }
-        return results;
+        return this.executeFormatterFunction(results);
+    }
+    
+    private executeFormatterFunction(data:CompleterItem[]): CompleterItem[]{
+        try{
+            let fn = this.formatterFunction;
+            if(typeof fn !== 'undefined' && fn !== null){
+                let temp:CompleterItem[] = fn(data);
+                return temp;
+            }
+        }catch(e){console.warn(e);}
+        return data;
     }
 }


### PR DESCRIPTION
Implementation of: https://github.com/oferh/ng2-completer/issues/228

with this feature we are able to format data who comes from server before it is showed.  It's based on https://github.com/ghiden/angucomplete-alt "remote-url-response-formatter", but instead of apply in raw data, i send formatted data, after 'extractMatches' method execution