### PR TITLE
add cacheSearchTerm option and index.ts file for easy npm install fro…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,16 @@
+export {Ng2CompleterModule} from "./src/ng2-completer.module";
+
+export {CompleterCmp} from "./src/components/completer-cmp";
+export {CompleterListItemCmp} from "./src/components/completer-list-item-cmp";
+export {CompleterService} from "./src/services/completer-service";
+export {CompleterData} from "./src/services/completer-data";
+export {localDataFactory, LocalDataFactoryProvider, remoteDataFactory, RemoteDataFactoryProvider} from "./src/services/completer-data-factory";
+export {CompleterItem} from "./src/components/completer-item";
+export {LocalData} from "./src/services/local-data";
+export {RemoteData} from "./src/services/remote-data";
+export {CompleterBaseData} from "./src/services/completer-base-data";
+export {CtrCompleter} from "./src/directives/ctr-completer";
+export {CtrDropdown} from "./src/directives/ctr-dropdown";
+export {CtrInput} from "./src/directives/ctr-input";
+export {CtrList} from "./src/directives/ctr-list";
+export {CtrRow} from "./src/directives/ctr-row";

--- a/src/components/completer-cmp.ts
+++ b/src/components/completer-cmp.ts
@@ -35,6 +35,7 @@ const COMPLETER_CONTROL_VALUE_ACCESSOR = {
             <div class="completer-dropdown-holder"
                 *ctrList="dataService;
                     minSearchLength: minSearchLength;
+                    cacheSearchTerm: cacheSearchTerm;
                     pause: pause;
                     autoMatch: autoMatch;
                     initialValue: initialValue;
@@ -136,6 +137,7 @@ export class CompleterCmp implements OnInit, ControlValueAccessor, AfterViewChec
     @Input() public openOnFocus = false;
     @Input() public initialValue: any;
     @Input() public autoHighlight = false;
+    @Input() public cacheSearchTerm = true;
 
     @Output() public selected = new EventEmitter<CompleterItem>();
     @Output() public highlighted = new EventEmitter<CompleterItem>();

--- a/src/directives/ctr-list.ts
+++ b/src/directives/ctr-list.ts
@@ -28,6 +28,7 @@ export class CtrList implements OnInit, CompleterList {
     @Input() public ctrListAutoMatch = false;
     @Input() public ctrListAutoHighlight = false;
     @Input() public ctrListDisplaySearching = true;
+    @Input() public ctrListCacheSearchTerm = true;
 
     private _dataService: CompleterData;
     // private results: CompleterItem[] = [];
@@ -100,7 +101,8 @@ export class CtrList implements OnInit, CompleterList {
     }
 
     public search(term: string) {
-        if (!isNil(term) && term.length >= this.ctrListMinSearchLength && this.term !== term) {
+        if (!isNil(term) && term.length >= this.ctrListMinSearchLength &&
+            (!this.ctrListCacheSearchTerm || (this.term !== term))) {
             if (this.searchTimer) {
                 this.searchTimer.unsubscribe();
                 this.searchTimer = null;
@@ -135,7 +137,7 @@ export class CtrList implements OnInit, CompleterList {
     }
 
     public open() {
-        if (!this.ctx.searchInitialized) {
+        if (!this.ctrListCacheSearchTerm || !this.ctx.searchInitialized) {
             this.search("");
         }
         this.refreshTemplate();


### PR DESCRIPTION
Add cacheSearchTerm option (defaults to true, the same behavior as before) to mitigate https://github.com/oferh/ng2-completer/issues/168

To fix the issue set cacheSearchTerm attribute of the ng2-completer to true.

Also add index.ts file, so ng2-completer could be installed from github like this: "yarn add yarn add https://github.com/oferh/ng2-completer