### PR TITLE
Fix package dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,14 +43,16 @@
     "@angular/compiler": ">=2.1.0",
     "@angular/core": ">=2.1.0",
     "@angular/forms": ">=2.1.0",
+    "@angular/http": ">=2.1.0",
     "@angular/platform-browser": ">=2.1.0",
-    "@angular/platform-browser-dynamic": ">=2.1.0"
+    "@angular/platform-browser-dynamic": ">=2.1.0",
+    "rxjs": ">=5.1.0",
+    "zone.js": ">=0.7.2"
   },
   "devDependencies": {
     "@angular/animations": ">=4.1.1",
     "@angular/cdk": "^2.0.0-beta.8",
     "@angular/compiler-cli": ">=2.1.0",
-    "@angular/http": ">=2.1.0",
     "@angular/material": ">=2.0.0-alpha.10",
     "@angular/platform-server": ">=2.1.0",
     "@angular/router": ">=3.1.0",
@@ -79,14 +81,12 @@
     "rollup": "^0.41.0",
     "rollup-plugin-uglify": "^1.0.1",
     "run-sequence": "^1.2.2",
-    "rxjs": "^5.1.0",
     "style-loader": "^0.18.2",
     "tslint": "^4.0.2",
     "typescript": "^2.1.0",
     "uglify-js": "^2.7.5",
     "webpack": "^2.1.0-beta.27",
     "webpack-dev-server": "^2.1.0-beta.12",
-    "webpack-merge": "^4.1.0",
-    "zone.js": "^0.7.2"
+    "webpack-merge": "^4.1.0"
   }
 }


### PR DESCRIPTION
Some production dependencies were incorrectly located under `devDependencies`. I noticed this as I was migrating from `@angular/http` to `@angular/common/http` in another application.

As a side-note. What are the plans for migration to `@angular/common/http` within `ng2-completer`? `@angular/common/http` requires Angular >= 4.3.0.