### PR TITLE
Fix #346 tab clears selection when clearUnselected is true

### DIFF
--- a/src/directives/ctr-input.ts
+++ b/src/directives/ctr-input.ts
@@ -214,7 +214,7 @@ export class CtrInput {
         } else if (this.overrideSuggested) {
             this.completer.onSelected({ title: this.searchStr, originalObject: null });
         } else {
-            if (this.clearUnselected) {
+            if (this.clearUnselected && !this.completer.hasSelected) {
                 this.searchStr = "";
                 this.ngModelChange.emit(this.searchStr);
             }


### PR DESCRIPTION
Also fixes the input that was being cleared when selecting a value with enter and then hitting enter again.

Issue #346 