### PR TITLE
feat: Adding option for disabled items on dropdown

### DIFF
--- a/demo/custom-data-with-disabled.ts
+++ b/demo/custom-data-with-disabled.ts
@@ -1,0 +1,35 @@
+import { HttpClient } from "@angular/common/http";
+import { Subject } from "rxjs/Subject";
+
+import { CompleterData, CompleterItem } from "../src/ng2-completer";
+
+export class CustomDataWithDisabled extends Subject<CompleterItem[]> implements CompleterData {
+    constructor(private http: HttpClient) {
+        super();
+    }
+    public search(term: string): void {
+        this.http.get(`https://mysafeinfo.com/api/data?list=beatlesalbums&format=json&abbreviate=false&case=default&typ=${term},contains`)
+            .map(data => {
+                let matches = (<Array<any>>data)
+                    .map((album: any) => this.convertToItem(album))
+                    .filter(album => !!album) as CompleterItem[];
+                this.next(matches);
+            })
+            .subscribe();
+    }
+
+    public cancel() {
+        // Handle cancel
+    }
+
+    public convertToItem(data: any): CompleterItem | null {
+        if (!data) {
+            return null;
+        }
+        return {
+            title: data.Album,
+            description: data.Label,
+            disabled: data.Label === "Apple"
+        } as CompleterItem;
+    }
+}

--- a/demo/native-cmp.html
+++ b/demo/native-cmp.html
@@ -197,6 +197,30 @@
     </div>
 </div>
 
+<h3>Custom data provider with disabled elements</h3>
+<p>Custom data provider. Beatles albums from <a href="https://mysafeinfo.com/">mysafeinfo.com</a>.</p>
+<p>Albums released with Apple Records are marked as disabled.</p>
+
+<div class="card">
+    <div class="card-block">
+        <div class="form-group row">
+            <div class="col-5">
+                <ng2-completer pause="400"
+                               [(ngModel)]="beatlesAlbums"
+                               [datasource]="beatlesCustomData"
+                               [minSearchLength]="3"
+                               [inputClass]="'form-control'"
+                               [placeholder]="'search Beatles albums'"
+                               [textSearching]="'Please wait...'">
+                </ng2-completer>
+            </div>
+            <div class="col-6">
+                <p class="form-control-static"><b> {{beatlesAlbums}}</b></p>
+            </div>
+        </div>
+    </div>
+</div>
+
 <h3>Open, close and focus programmatically</h3>
 <p>Local data of colors; Open, Close and Focus programmatically and set ngModel to an initial value with <code>openOnFocus</code>,
     <code>autoHighlight</code>,

--- a/demo/native-cmp.ts
+++ b/demo/native-cmp.ts
@@ -13,6 +13,7 @@ import {
 } from "../src/ng2-completer";
 import { CustomData } from "./custom-data";
 import { HttpClient } from "@angular/common/http";
+import { CustomDataWithDisabled } from "./custom-data-with-disabled";
 
 let template = require("./native-cmp.html");
 let style = require("./native-cmp.css");
@@ -79,6 +80,7 @@ export class NativeCmp {
     public dataService3: CompleterData;
     public dataService4: CompleterData;
     public customData: CustomData;
+    public beatlesCustomData: CustomDataWithDisabled;
     public isOpen: boolean = false;
 
     @ViewChild("openCloseExample") private openCloseExample: CompleterCmp;
@@ -104,6 +106,7 @@ export class NativeCmp {
         const source = from([this.countries]).delay(3000);
         this.dataService3 = completerService.local(source, "name", "name");
         this.customData = new CustomData(http);
+        this.beatlesCustomData = new CustomDataWithDisabled(http);
         this.dataService4 = completerService.local(this.colors, null, null);
     }
 

--- a/src/components/completer-cmp.ts
+++ b/src/components/completer-cmp.ts
@@ -55,7 +55,7 @@ const COMPLETER_CONTROL_VALUE_ACCESSOR = {
                     <div *ngIf="!searchActive && (!items || items?.length === 0)"
                     class="completer-no-results">{{ _textNoResults }}</div>
                     <div class="completer-row-wrapper" *ngFor="let item of items; let rowIndex=index">
-                        <div class="completer-row" [ctrRow]="rowIndex" [dataItem]="item">
+                        <div class="completer-row" [ctrRow]="rowIndex" [dataItem]="item" [ngClass]="{'completer-row-disabled': item.disabled }">
                             <div *ngIf="item.image || item.image === ''" class="completer-image-holder">
                                 <img *ngIf="item.image != ''" src="{{item.image}}" class="completer-image" />
                                 <div *ngIf="item.image === ''" class="completer-image-default"></div>
@@ -98,6 +98,11 @@ const COMPLETER_CONTROL_VALUE_ACCESSOR = {
         clear: both;
         display: inline-block;
         width: 103%;
+    }
+
+    .completer-row-disabled {
+        color: #dddddd;
+        pointer-events: none;
     }
 
     .completer-selected-row {

--- a/src/components/completer-item.ts
+++ b/src/components/completer-item.ts
@@ -3,4 +3,5 @@ export interface CompleterItem {
     description?: string;
     image?: string;
     originalObject: any;
+    disabled?: boolean;
 };


### PR DESCRIPTION
Adds the option to have disabled items when using custom data.

<img width="800" alt="screen shot 2019-02-12 at 10 36 05 pm" src="https://user-images.githubusercontent.com/358892/52680739-5bf4c800-2f18-11e9-86f6-d7eb9a8b0931.png">


- Added an optional `disabled` attribute to `CompleterItem`
- Added a class `completer-row-disabled` for disabled row.
- Added an example, similar to the one with Seinfeld episodes.