### PR TITLE
change value of html autocomplete attribute

### DIFF
--- a/src/components/completer-cmp.ts
+++ b/src/components/completer-cmp.ts
@@ -35,7 +35,7 @@ const COMPLETER_CONTROL_VALUE_ACCESSOR = {
                 [openOnClick]="openOnClick" [selectOnClick]="selectOnClick" [selectOnFocus]="selectOnFocus"
                 (blur)="onBlur()" (focus)="onFocus()" (keyup)="onKeyup($event)"
                 (keydown)="onKeydown($event)" (click)="onClick($event)"
-                autocomplete="off" autocorrect="off" autocapitalize="off" />
+                autocomplete="ng2-completer" autocorrect="off" autocapitalize="off" />
 
             <div class="completer-dropdown-holder"
                 *ctrList="dataService;


### PR DESCRIPTION

Chrome doesn't take into account any more the html autocomplete="off" attribute.
As a result, the browser's autocomplete suggestions will overlap the suggestions we actually want to display with this component.

The only available workaround for now seems to be to give a value which is semantically significant for the given input, but which can't be interpreted by the browser as a known value for autocomplete.

See here, the reply from Chromium on this specific issue: https://bugs.chromium.org/p/chromium/issues/detail?id=468153#c164
> In cases where you really want to disable autofill, our suggestion at this point is to utilize the autocomplete attribute to give valid, semantic meaning to your fields. If we encounter an autocomplete attribute that we don't recognize, we won't try and fill it.
