### PR TITLE
Report observable leaks in demo project

### DIFF
--- a/demo/boot.ts
+++ b/demo/boot.ts
@@ -1,12 +1,24 @@
 "use strict";
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from "@angular/platform-browser-dynamic";
+import { Observable } from 'rxjs';
+import { setup, track, printSubscribers } from 'observable-profiler';
 
 import { AppModule } from './app-module';
 
 if ("production" === ENV) {
-  // Production
-  enableProdMode();
+    // Production
+    enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule);
+setup(Observable);
+platformBrowserDynamic().bootstrapModule(AppModule).then((ref) => {
+    track();
+    (window as any).stopProfiler = () => {
+        ref.destroy();
+        const subscribers = track(false);
+        printSubscribers({
+            subscribers,
+        });
+    };
+});

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "karma-spec-reporter": "^0.0.32",
     "karma-webpack": "^3.0.0",
     "ngx-bootstrap": "^3.0.0",
+    "observable-profiler": "^0.1.1",
     "raw-loader": "^0.5.1",
     "reflect-metadata": "^0.1.10",
     "rollup": "^0.60.1",


### PR DESCRIPTION
Adding [observable-profiler](https://www.npmjs.com/package/observable-profiler) to the demo project to help identify observable leaks, that is, subscriptions to observables that don't complete, nor are manually unsubscribed.

Usage:

1. Run the project;
2. Click once on each top-level link (to load each page once, ignoring initial navigation);
3. Open devtools and run `stopProfiler()` in console.

This does not fix any leaks, only reports them.