### PR TITLE
Removed rxjs-compat dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,5 @@
     "webpack-dev-server": "^3.1.4",
     "webpack-merge": "^4.1.0",
     "zone.js": "~0.8.18"
-  },
-  "dependencies": {
-    "rxjs-compat": "^6.2.2"
   }
 }


### PR DESCRIPTION
Based on https://github.com/oferh/ng2-completer/pull/401, and some testing, it seems the `rxjs-compat` is not necessary for this package. Feel it should be removed.