### PR TITLE
Remove deprecated @angular/http, and move to @angular/common/http

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@angular/compiler-cli": ">= 6.0.0",
     "@angular/core": ">= 6.0.0",
     "@angular/forms": ">= 6.0.0",
-    "@angular/http": ">= 6.0.0",
     "@angular/material": ">= 6.0.0",
     "@angular/platform-browser": ">= 6.0.0",
     "@angular/platform-browser-dynamic": ">= 6.0.0",

--- a/src/services/remote-data.ts
+++ b/src/services/remote-data.ts
@@ -5,7 +5,6 @@ import { catchError, map } from "rxjs/operators";
 
 import { CompleterBaseData } from "./completer-base-data";
 import { CompleterItem } from "../components/completer-item";
-import { RequestOptions } from "@angular/http";
 
 export class RemoteData extends CompleterBaseData {
     public dataSourceChange: EventEmitter<void> = new EventEmitter<void>();


### PR DESCRIPTION
Removed `@angular/http` from the dependencies, since it is deprecated. Removed the last reference to it.