### PR TITLE
fix(build): disable Ivy and remove postinstall script

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,6 +2,7 @@
 
 const shell = require('shelljs');
 const chalk = require('chalk');
+const path = require('path');
 
 const PACKAGE = `ng2-completer`;
 const NPM_DIR = `dist/lib`;
@@ -69,5 +70,8 @@ shell.rm(`-Rf`, `${NPM_DIR}/src/**/*.js`);
 shell.rm(`-Rf`, `${NPM_DIR}/src/**/*.js.map`);
 
 shell.cp(`-Rf`, [`package.json`, `LICENSE.md`, `README.md`], `${NPM_DIR}`);
+
+const packageJsonPath = path.join(__dirname, NPM_DIR, 'package.json');
+shell.sed('-i', /^.+postinstall.+$/, '', packageJsonPath);
 
 shell.echo(chalk.green(`End building`));

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -34,6 +34,7 @@
         "annotateForClosureCompiler": false,
         "strictMetadataEmit": true,
         "flatModuleOutFile": "ng2-completer.js",
-        "flatModuleId": "ng2-completer"
+        "flatModuleId": "ng2-completer",
+        "enableIvy": false
     }
 }


### PR DESCRIPTION
Fixes issues in the build process of the package:
 - disables Ivy when building package for publishing as per [Angular recommendation](angular.io/guide/creating-libraries#publishing-your-library). 
 - removes `postinstall` script from `package.json` before publishing package as it fails on `npm install` https://github.com/oferh/ng2-completer/issues/447#issuecomment-594005303.

Merging this PR will allow releasing the correctly built package.