### PR TITLE
Fix selected event not working on 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,12 +93,13 @@
     "source-map-loader": "0.2.3",
     "ts-loader": "^4.4.1",
     "tslint": "^5.10.0",
-    "typescript": "2.7.2",
+    "typescript": "3.5.3",
     "uglify-js": "^3.1.6",
     "webpack": "^4.0.0",
     "webpack-cli": "^3.0.3",
     "webpack-dev-server": "^3.1.4",
     "webpack-merge": "^4.1.0",
     "zone.js": "~0.8.18"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/components/completer-cmp.ts
+++ b/src/components/completer-cmp.ts
@@ -125,7 +125,7 @@ const COMPLETER_CONTROL_VALUE_ACCESSOR = {
     `],
     providers: [COMPLETER_CONTROL_VALUE_ACCESSOR]
 })
-export class CompleterCmp implements OnInit, ControlValueAccessor, AfterViewChecked, AfterViewInit {
+export class CompleterCmp implements ControlValueAccessor, AfterViewChecked, AfterViewInit {
     @Input() public dataService: CompleterData | undefined;
     @Input() public inputName = "";
     @Input() public inputId: string = "";
@@ -202,6 +202,21 @@ export class CompleterCmp implements OnInit, ControlValueAccessor, AfterViewChec
         if (this.autofocus) {
             this._focus = true;
         }
+        
+        if (!this.completer) {
+            return;
+        }
+
+        this.completer.selected.subscribe((item: CompleterItem) => {
+            this.selected.emit(item);
+        });
+        this.completer.highlighted.subscribe((item: CompleterItem) => {
+            this.highlighted.emit(item);
+        });
+        this.completer.opened.subscribe((isOpen: boolean) => {
+            this._open = isOpen;
+            this.opened.emit(isOpen);
+        });
     }
 
     public ngAfterViewChecked(): void {
@@ -265,24 +280,6 @@ export class CompleterCmp implements OnInit, ControlValueAccessor, AfterViewChec
             this._textSearching = text;
             this.displaySearching = !!this._textSearching && this._textSearching !== "false";
         }
-    }
-
-    public ngOnInit() {
-
-        if (!this.completer) {
-            return;
-        }
-
-        this.completer.selected.subscribe((item: CompleterItem) => {
-            this.selected.emit(item);
-        });
-        this.completer.highlighted.subscribe((item: CompleterItem) => {
-            this.highlighted.emit(item);
-        });
-        this.completer.opened.subscribe((isOpen: boolean) => {
-            this._open = isOpen;
-            this.opened.emit(isOpen);
-        });
     }
 
     public onBlur() {

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -30,7 +30,7 @@
     ],
     "angularCompilerOptions": {
         "skipTemplateCodegen": true,
-        "annotateForClosureCompiler": true,
+        "annotateForClosureCompiler": false,
         "strictMetadataEmit": true,
         "flatModuleOutFile": "ng2-completer.js",
         "flatModuleId": "ng2-completer"


### PR DESCRIPTION
Move selected event subscription code into ngAfterViewInit. 
`this.completer` is stilll undefined in `ngOnInit`, that's the reason why we couldn't subscribe to selected event.

Fix for #442 